### PR TITLE
Persist the key info in the store

### DIFF
--- a/test/keychain.spec.js
+++ b/test/keychain.spec.js
@@ -271,6 +271,16 @@ module.exports = (datastore1, datastore2) => {
           done()
         })
       })
+
+      it('key exists', (done) => {
+        ks.findKeyByName('alice', (err, key) => {
+          expect(err).to.not.exist()
+          expect(key).to.exist()
+          expect(key).to.have.property('name', 'alice')
+          expect(key).to.have.property('id', alice.toB58String())
+          done()
+        })
+      })
     })
 
     describe('rename', () => {


### PR DESCRIPTION
Instead of generating the KeyInfo on the fly, which requires reading the private key, put the KeyInfo into the store when the key is generated/imported into the keychain.

See also issue #8