### PR TITLE
Fix out of date npms

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "async": "^2.6.0",
     "deepmerge": "^1.5.2",
     "interface-datastore": "~0.4.2",
-    "libp2p-crypto": "~0.12.0",
+    "libp2p-crypto": "~0.13.0",
     "pull-stream": "^3.6.1",
     "sanitize-filename": "^1.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {
-    "aegir": "^12.4.0",
+    "aegir": "^13.0.7",
     "chai": "^4.1.2",
     "chai-string": "^1.4.0",
     "datastore-fs": "~0.4.2",

--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
   "homepage": "https://github.com/libp2p/js-libp2p-keychain#readme",
   "dependencies": {
     "async": "^2.6.0",
-    "deepmerge": "^1.5.2",
     "interface-datastore": "~0.4.2",
     "libp2p-crypto": "~0.13.0",
+    "lodash.merge": "^4.6.1",
     "pull-stream": "^3.6.1",
     "sanitize-filename": "^1.6.1"
   },

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -2,7 +2,7 @@
 'use strict'
 
 const sanitize = require('sanitize-filename')
-const deepmerge = require('deepmerge')
+const deepmerge = require('lodash.merge')
 const crypto = require('libp2p-crypto')
 const DS = require('interface-datastore')
 const pull = require('pull-stream')
@@ -104,7 +104,8 @@ class Keychain {
     }
     this.store = store
 
-    const opts = deepmerge(defaultOptions, options)
+    const opts = {}
+    deepmerge(opts, defaultOptions, options)
 
     // Enforce NIST SP 800-132
     if (!opts.passPhrase || opts.passPhrase.length < 20) {


### PR DESCRIPTION
I updated deepmerge and libp2p-crypto npms for dependencies out of date.
Also, I added `.aegir.js` file for fixing deepmerge's issue. https://github.com/KyleAMathews/deepmerge/issues/87

We can choice to wait until fix the issue. Thought ?