### PR TITLE
chore: allow keychain interactions without a password

### DIFF
--- a/src/keychain.js
+++ b/src/keychain.js
@@ -25,7 +25,8 @@ const defaultOptions = {
     iterationCount: 10000,
     salt: 'you should override this value with a crypto secure random number',
     hash: 'sha2-512'
-  }
+  },
+  passPhrase: 'correcthorsebatterystaple'
 }
 
 function validateKeyName (name) {

--- a/test/keychain.spec.js
+++ b/test/keychain.spec.js
@@ -25,8 +25,8 @@ module.exports = (datastore1, datastore2) => {
       done()
     })
 
-    it('needs a pass phrase to encrypt a key', () => {
-      expect(() => new Keychain(datastore2)).to.throw()
+    it('does not need a pass phrase to encrypt a key', () => {
+      expect(() => new Keychain(datastore2)).to.not.throw()
     })
 
     it('needs a NIST SP 800-132 non-weak pass phrase', () => {


### PR DESCRIPTION
Possibly contentious PR, but go-ipfs does not require a password to list or generate keys but js-ipfs does.  This prevents us from having interop as the behaviour is different.

This PR sets a silly default password, but I'm not 100% convince it's a good idea.

Needed for the tests in https://github.com/ipfs/js-ipfs/pull/1548 and https://github.com/ipfs/interop/pull/35 to pass.