### PR TITLE
chore: downgrade peer-id to same version used by libp2p

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "err-code": "^2.0.0",
     "interface-datastore": "^0.7.0",
-    "libp2p-crypto": "^0.17.0",
+    "libp2p-crypto": "^0.16.2",
     "merge-options": "^1.0.1",
     "node-forge": "^0.8.5",
     "sanitize-filename": "^1.6.1"
@@ -56,7 +56,7 @@
     "dirty-chai": "^2.0.1",
     "level": "^5.0.1",
     "multihashes": "^0.4.15",
-    "peer-id": "^0.13.2",
+    "peer-id": "^0.12.2",
     "promisify-es6": "^1.0.3",
     "rimraf": "^2.6.3"
   },

--- a/src/keychain.js
+++ b/src/keychain.js
@@ -5,6 +5,7 @@ const sanitize = require('sanitize-filename')
 const mergeOptions = require('merge-options')
 const crypto = require('libp2p-crypto')
 const DS = require('interface-datastore')
+const promisify = require('promisify-es6')
 const CMS = require('./cms')
 const errcode = require('err-code')
 
@@ -205,10 +206,16 @@ class Keychain {
 
     let keyInfo
     try {
-      const keypair = await crypto.keys.generateKeyPair(type, size)
+      const keypair = await promisify(crypto.keys.generateKeyPair, {
+        context: crypto.keys
+      })(type, size)
 
-      const kid = await keypair.id()
-      const pem = await keypair.export(this._())
+      const kid = await promisify(keypair.id, {
+        context: keypair
+      })()
+      const pem = await promisify(keypair.export, {
+        context: keypair
+      })(this._())
       keyInfo = {
         name: name,
         id: kid
@@ -360,8 +367,12 @@ class Keychain {
     try {
       const res = await this.store.get(dsname)
       const pem = res.toString()
-      const privateKey = await crypto.keys.import(pem, this._())
-      return privateKey.export(password)
+      const privateKey = await promisify(crypto.keys.import, {
+        context: crypto.keys
+      })(pem, this._())
+      return promisify(privateKey.export, {
+        context: privateKey
+      })(password)
     } catch (err) {
       return throwDelayed(err)
     }
@@ -389,15 +400,21 @@ class Keychain {
 
     let privateKey
     try {
-      privateKey = await crypto.keys.import(pem, password)
+      privateKey = await promisify(crypto.keys.import, {
+        context: crypto.keys
+      })(pem, password)
     } catch (err) {
       return throwDelayed(errcode(new Error('Cannot read the key, most likely the password is wrong'), 'ERR_CANNOT_READ_KEY'))
     }
 
     let kid
     try {
-      kid = await privateKey.id()
-      pem = await privateKey.export(this._())
+      kid = await promisify(privateKey.id, {
+        context: privateKey
+      })()
+      pem = await promisify(privateKey.export, {
+        context: privateKey
+      })(this._())
     } catch (err) {
       return throwDelayed(err)
     }
@@ -429,8 +446,12 @@ class Keychain {
     if (exists) return throwDelayed(errcode(new Error(`Key '${name}' already exists`), 'ERR_KEY_ALREADY_EXISTS'))
 
     try {
-      const kid = await privateKey.id()
-      const pem = await privateKey.export(this._())
+      const kid = await promisify(privateKey.id, {
+        context: privateKey
+      })()
+      const pem = await promisify(privateKey.export, {
+        context: privateKey
+      })(this._())
       const keyInfo = {
         name: name,
         id: kid

--- a/test/keychain.spec.js
+++ b/test/keychain.spec.js
@@ -9,6 +9,7 @@ chai.use(require('dirty-chai'))
 chai.use(require('chai-string'))
 const Keychain = require('../')
 const PeerId = require('peer-id')
+const promisify = require('promisify-es6')
 
 module.exports = (datastore1, datastore2) => {
   describe('keychain', () => {
@@ -268,7 +269,7 @@ module.exports = (datastore1, datastore2) => {
 
       before(async function () {
         const encoded = Buffer.from(alicePrivKey, 'base64')
-        alice = await PeerId.createFromPrivKey(encoded)
+        alice = await promisify(PeerId.createFromPrivKey)(encoded)
       })
 
       it('private key can be imported', async () => {

--- a/test/node.js
+++ b/test/node.js
@@ -8,8 +8,8 @@ const rimraf = promisify(require('rimraf'))
 const FsStore = require('datastore-fs')
 
 describe('node', () => {
-  const store1 = path.join(os.tmpdir(), 'test-keystore-1')
-  const store2 = path.join(os.tmpdir(), 'test-keystore-2')
+  const store1 = path.join(os.tmpdir(), 'test-keystore-1-' + Date.now())
+  const store2 = path.join(os.tmpdir(), 'test-keystore-2-' + Date.now())
   const datastore1 = new FsStore(store1)
   const datastore2 = new FsStore(store2)
 

--- a/test/peerid.js
+++ b/test/peerid.js
@@ -10,6 +10,7 @@ const multihash = require('multihashes')
 const crypto = require('libp2p-crypto')
 const rsaUtils = require('libp2p-crypto/src/keys/rsa-utils')
 const rsaClass = require('libp2p-crypto/src/keys/rsa-class')
+const promisify = require('promisify-es6')
 
 const sample = {
   id: '122019318b6e5e0cf93a2314bf01269a2cc23cd3dcd452d742cdb9379d8646f6e4a9',
@@ -23,10 +24,10 @@ describe('peer ID', () => {
 
   before(async () => {
     const encoded = Buffer.from(sample.privKey, 'base64')
-    peer = await PeerId.createFromPrivKey(encoded)
+    peer = await promisify(PeerId.createFromPrivKey)(encoded)
   })
 
-  it('decoded public key', () => {
+  it('decoded public key', async () => {
     // get protobuf version of the public key
     const publicKeyProtobuf = peer.marshalPubKey()
     const publicKey = crypto.keys.unmarshalPublicKey(publicKeyProtobuf)
@@ -34,14 +35,18 @@ describe('peer ID', () => {
 
     // get protobuf version of the private key
     const privateKeyProtobuf = peer.marshalPrivKey()
-    const key = crypto.keys.unmarshalPrivateKey(privateKeyProtobuf)
+    const key = await promisify(crypto.keys.unmarshalPrivateKey, {
+      context: crypto.keys
+    })(privateKeyProtobuf)
     expect(key).to.exist()
   })
 
   it('encoded public key with DER', async () => {
     const jwk = rsaUtils.pkixToJwk(publicKeyDer)
     const rsa = new rsaClass.RsaPublicKey(jwk)
-    const keyId = await rsa.hash()
+    const keyId = await promisify(rsa.hash, {
+      context: rsa
+    })()
     const kids = multihash.toB58String(keyId)
     expect(kids).to.equal(peer.toB58String())
   })
@@ -55,7 +60,9 @@ describe('peer ID', () => {
       kid: '2011-04-29'
     }
     const rsa = new rsaClass.RsaPublicKey(jwk)
-    const keyId = await rsa.hash()
+    const keyId = await promisify(rsa.hash, {
+      context: rsa
+    })()
     const kids = multihash.toB58String(keyId)
     expect(kids).to.equal(peer.toB58String())
   })
@@ -63,7 +70,9 @@ describe('peer ID', () => {
   it('decoded private key', async () => {
     // get protobuf version of the private key
     const privateKeyProtobuf = peer.marshalPrivKey()
-    const key = await crypto.keys.unmarshalPrivateKey(privateKeyProtobuf)
+    const key = await promisify(crypto.keys.unmarshalPrivateKey, {
+      context: crypto.keys
+    })(privateKeyProtobuf)
     expect(key).to.exist()
   })
 })


### PR DESCRIPTION
Downgrades the `peer-id` dependency to the same version used by the current `libp2p` release in order to not have mixed versions of `peer-id` in the dependency tree because `libp2p@0.26.x` can't dial anything from `peer-id@0.13.x` without upgrading it and every module it depends on.

My feeling is we'll upgrade everything when the `libp2p` async iterator refactor lands.

Depends on libp2p/js-libp2p-crypto#158