### PR TITLE
chore: update node-forge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "interface-datastore": "^0.7.0",
     "libp2p-crypto": "^0.16.2",
     "merge-options": "^1.0.1",
-    "node-forge": "^0.8.5",
+    "node-forge": "^0.9.1",
     "sanitize-filename": "^1.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
2 versions of node-forge in the dependency tree make for a very big bundle.

<img width="622" alt="Screenshot 2019-12-02 at 15 58 59" src="https://user-images.githubusercontent.com/152863/69974247-c82ecf80-151c-11ea-8655-5ec0d0f55ebd.png">
