### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: libp2p-keychain is now in [libp2p/src/keychain](https://github.com/libp2p/js-libp2p/tree/master/src/keychain)
+======
+
 # js-libp2p-keychain
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-⛔️ DEPRECATED: libp2p-keychain is now in [libp2p/src/keychain](https://github.com/libp2p/js-libp2p/tree/master/src/keychain)
+⛔️ DEPRECATED: libp2p-keychain is now in [libp2p/src/keychain](https://github.com/libp2p/js-libp2p/tree/master/src/keychain) per [libp2p@0.28.0](https://github.com/libp2p/js-libp2p/releases/tag/v0.28.0).
 ======
 
 # js-libp2p-keychain


### PR DESCRIPTION
In the context of https://github.com/libp2p/js-libp2p/issues/509, https://github.com/libp2p/js-libp2p/issues/592 and https://github.com/libp2p/js-libp2p/pull/633, a deprecation notice is added.

Needs:

- [x]  npm deprecation notice

After merged, the repo must be archived